### PR TITLE
Update login.component.ts

### DIFF
--- a/src/login/pages/login/login.component.ts
+++ b/src/login/pages/login/login.component.ts
@@ -36,7 +36,7 @@ export class LoginComponent extends ComponentReference {
 
     displayRequiredFields = false;
     displayInfo = !!this.kcContext?.realm?.password && !!this.kcContext?.realm?.registrationAllowed && !this.kcContext?.registrationDisabled;
-    displayMessage = this.kcContext?.messagesPerField?.existsError('username', 'password');
+    displayMessage = !this.kcContext?.messagesPerField?.existsError('username', 'password');
 
     headerNode = viewChild<TemplateRef<HTMLElement>>('headerNode');
     infoNode = viewChild<TemplateRef<HTMLElement>>('infoNode');


### PR DESCRIPTION
Fix: Check corrected to show banner message only in case there is no error on either username/ password

Currently, the banner message below header is only displayed when there is an error on either user name or password when used with keylock installation. The same can also be confirmed with story book with-immutable-preset-username or with-error-message where the info/ error message is not be shown.

The PR fixes this issue. 