### PR TITLE
fix: sanitize back to application html text

### DIFF
--- a/src/account/pages/account/account.component.html
+++ b/src/account/pages/account/account.component.html
@@ -137,7 +137,11 @@
         >
             <div>
                 @if (referrer) {
-                    <a [href]="referrer?.url">{{ i18n.msgStr('backToApplication') }}</a>
+                    <a
+                        [href]="referrer!.url"
+                        [innerHTML]="i18n.msgStr('backToApplication') | kcSanitize: 'html'"
+                    >
+                    </a>
                 }
                 <button
                     type="submit"

--- a/src/account/pages/account/account.component.ts
+++ b/src/account/pages/account/account.component.ts
@@ -7,11 +7,12 @@ import type { KcContext } from '@keycloakify/angular/account/KcContext';
 import { ACCOUNT_CLASSES } from '@keycloakify/angular/account/tokens/classes';
 import { ACCOUNT_I18N } from '@keycloakify/angular/account/tokens/i18n';
 import { KC_ACCOUNT_CONTEXT } from '@keycloakify/angular/account/tokens/kc-context';
+import { KcSanitizePipe } from '@keycloakify/angular/lib/pipes/kc-sanitize';
 import { USE_DEFAULT_CSS } from '@keycloakify/angular/lib/tokens/use-default-css';
 import type { ClassKey } from 'keycloakify/account';
 
 @Component({
-    imports: [KcClassDirective, NgClass],
+    imports: [NgClass, KcClassDirective, KcSanitizePipe],
     selector: 'kc-account',
     templateUrl: 'account.component.html',
     providers: [

--- a/src/login/pages/logout-confirm/logout-confirm.component.html
+++ b/src/login/pages/logout-confirm/logout-confirm.component.html
@@ -42,7 +42,11 @@
     <div id="kc-info-message">
         @if (!logoutConfirm.skipLink && client.baseUrl) {
             <p>
-                <a [href]="client.baseUrl">{{ i18n.msgStr('backToApplication') }}</a>
+                <a
+                    [href]="client.baseUrl"
+                    [innerHTML]="i18n.msgStr('backToApplication') | kcSanitize: 'html'"
+                >
+                </a>
             </p>
         }
     </div>

--- a/src/login/pages/logout-confirm/logout-confirm.component.ts
+++ b/src/login/pages/logout-confirm/logout-confirm.component.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, forwardRef, inject, type TemplateRef, viewChild } from '@angular/core';
+import { KcSanitizePipe } from '@keycloakify/angular/lib/pipes/kc-sanitize';
 import { ComponentReference } from '@keycloakify/angular/login/classes/component-reference';
 import { KcClassDirective } from '@keycloakify/angular/login/directives/kc-class';
 import type { I18n } from '@keycloakify/angular/login/i18n';
@@ -7,7 +8,7 @@ import { LOGIN_I18N } from '@keycloakify/angular/login/tokens/i18n';
 import { KC_LOGIN_CONTEXT } from '@keycloakify/angular/login/tokens/kc-context';
 
 @Component({
-    imports: [KcClassDirective],
+    imports: [KcSanitizePipe, KcClassDirective],
     selector: 'kc-logout-confirm',
     templateUrl: 'logout-confirm.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly renders the “Back to application” link with translation formatting on account and logout confirmation pages.
  * Ensures any HTML in translated link text is safely sanitized before display.
  * Improves consistency of link behavior when a return URL is available.

* **Refactor**
  * Updated templates to use safe HTML rendering for translated link content, aligning both pages with a consistent approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->